### PR TITLE
Implement temperature units in the API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -87,12 +87,12 @@ class Thermostat {
 
   handleTemperatureDisplayUnitsGet() {
     this.log.debug('GET TemperatureDisplayUnits');
-    return this.hap.Characteristic.TemperatureDisplayUnits.FAHRENHEIT;
+    return this.schluterAPI.getTemperatureUnit();
   }
 
-  handleTemperatureDisplayUnitsSet() {
+  handleTemperatureDisplayUnitsSet(value) {
     this.log.debug('SET TemperatureDisplayUnits');
-    return this.hap.Characteristic.TemperatureDisplayUnits.FAHRENHEIT;
+    this.schluterAPI.setTemperatureUnit(value);
   }
 
   getServices(){

--- a/src/schluter-api.ts
+++ b/src/schluter-api.ts
@@ -6,6 +6,11 @@ type ThermostatState = {
   targetTemperature: number;
 };
 
+enum TemperatureUnit {
+  Celsius = 0,
+  Fahrenheit = 1
+}
+
 export class SchluterAPI {
   private readonly email: string;
   private readonly password: string;
@@ -25,6 +30,25 @@ export class SchluterAPI {
 
   async getTargetTemperature(): Promise<number> {
     return (await this.thermostatState()).targetTemperature;
+  }
+
+  async getTemperatureUnit(): Promise<TemperatureUnit> {
+    const sessionId = await this.login();
+    const params = { sessionid: sessionId };
+    const result = await axios.get(this.accountUrl(), { params: params });
+
+    if (result.data.TempUnitIsCelsius) {
+      return TemperatureUnit.Celsius;
+    } else {
+      return TemperatureUnit.Fahrenheit;
+    }
+  }
+
+  async setTemperatureUnit(value: TemperatureUnit) {
+    const sessionId = await this.login();
+    const params = { sessionid: sessionId };
+    const data = { TempUnitIsCelsius: value === TemperatureUnit.Celsius };
+    await axios.put(this.accountUrl(), data, { params: params });
   }
 
   async setTargetTemperature(targetTemperature: number) {
@@ -60,5 +84,9 @@ export class SchluterAPI {
 
   private signInUrl() {
     return 'https://ditra-heat-e-wifi.schluter.com/api/authenticate/user';
+  }
+
+  private accountUrl() {
+    return 'https://ditra-heat-e-wifi.schluter.com/api/useraccount';
   }
 }


### PR DESCRIPTION
This allows reading and setting the thermostat temperature display units. I've verified that these methods read and write the data appropriately. Changing the unit via the API does update the accessory settings visible in the home app, although the tile remains in Fahrenheit. I think that part might have to do with the locale of the device though.

Closes #3