### PR TITLE
Reuse Schluter session ids when possible

### DIFF
--- a/src/schluter-api.ts
+++ b/src/schluter-api.ts
@@ -12,16 +12,59 @@ enum TemperatureUnit {
 }
 
 export class SchluterAPI {
+  private static signInUrl = 'https://ditra-heat-e-wifi.schluter.com/api/authenticate/user';
+  private static thermostatUrl = 'https://ditra-heat-e-wifi.schluter.com/api/thermostat';
+  private static accountUrl = 'https://ditra-heat-e-wifi.schluter.com/api/useraccount';
+
   private readonly email: string;
   private readonly password: string;
   private readonly serialNumber: string;
   private readonly log: Logging;
+  private sessionId: string | null;
 
   constructor(email: string, password: string, serialNumber: string, log: Logging) {
     this.email = email;
     this.password = password;
     this.serialNumber = serialNumber;
     this.log = log;
+    this.sessionId = null;
+
+    axios.interceptors.request.use(this.appendSessionId.bind(this));
+    axios.interceptors.response.use(undefined, this.clearSessionId.bind(this));
+  }
+
+  private async appendSessionId(request) {
+    if (request.url !== SchluterAPI.signInUrl) {
+      this.sessionId = this.sessionId || await this.signIn();
+      this.log.debug('Appending session ID %s to request', this.sessionId);
+      request.params = request.params || {};
+      request.params.sessionid = this.sessionId;
+    }
+
+    return request;
+  }
+
+  private async clearSessionId(error) {
+    if (error.response?.status === 401) {
+      this.log.debug('401 Unauthorized, clearing session ID');
+      this.sessionId = null;
+      return error;
+    }
+
+    return Promise.reject(error);
+  }
+
+  private async signIn(): Promise<string> {
+    const data = { email: this.email, password: this.password };
+
+    const result = await axios.post(SchluterAPI.signInUrl, data);
+
+    switch (result.data.ErrorCode) {
+      case 0: { return result.data.SessionId; }
+      case 1: { throw new Error('Sign in: invalid email'); }
+      case 2: { throw new Error('Sign in: invalid password'); }
+      default: { throw new Error('Sign in: unknown error'); }
+    }
   }
 
   async getTemperature(): Promise<number> {
@@ -33,9 +76,7 @@ export class SchluterAPI {
   }
 
   async getTemperatureUnit(): Promise<TemperatureUnit> {
-    const sessionId = await this.login();
-    const params = { sessionid: sessionId };
-    const result = await axios.get(this.accountUrl(), { params: params });
+    const result = await axios.get(SchluterAPI.accountUrl);
 
     if (result.data.TempUnitIsCelsius) {
       return TemperatureUnit.Celsius;
@@ -45,48 +86,27 @@ export class SchluterAPI {
   }
 
   async setTemperatureUnit(value: TemperatureUnit) {
-    const sessionId = await this.login();
-    const params = { sessionid: sessionId };
     const data = { TempUnitIsCelsius: value === TemperatureUnit.Celsius };
-    await axios.put(this.accountUrl(), data, { params: params });
+    await axios.put(SchluterAPI.accountUrl, data);
   }
 
   async setTargetTemperature(targetTemperature: number) {
-    const sessionId = await this.login();
-    const params = { serialnumber: this.serialNumber, sessionid: sessionId };
+    const params = { serialnumber: this.serialNumber };
     const data = {
       ComfortTemperature: Math.round(targetTemperature * 100),
       RegulationMode: 2,
     };
 
-    await axios.post(this.thermostatUrl(), data, { params: params });
+    await axios.post(SchluterAPI.thermostatUrl, data, { params: params });
   }
 
   private async thermostatState(): Promise<ThermostatState> {
-    const sessionId = await this.login();
+    const sessionId = await this.signIn();
     const params = { serialnumber: this.serialNumber, sessionid: sessionId };
-    const result = await axios.get(this.thermostatUrl(), { params: params });
+    const result = await axios.get(SchluterAPI.thermostatUrl, { params: params });
     return {
       temperature: result.data.Temperature/100,
       targetTemperature: result.data.SetPointTemp/100,
     };
-  }
-
-  private async login() {
-    const data = { email: this.email, password: this.password };
-    const result = await axios.post(this.signInUrl(), data);
-    return result.data.SessionId;
-  }
-
-  private thermostatUrl() {
-    return 'https://ditra-heat-e-wifi.schluter.com/api/thermostat';
-  }
-
-  private signInUrl() {
-    return 'https://ditra-heat-e-wifi.schluter.com/api/authenticate/user';
-  }
-
-  private accountUrl() {
-    return 'https://ditra-heat-e-wifi.schluter.com/api/useraccount';
   }
 }


### PR DESCRIPTION
Previously, we were logging in on every single request to the API, even
though session ids seem to be valid for somewhere between 30-60 minutes.
We now store the most recent session id in state and use an interceptor
to append it to all requests that are not sign in requests.

I also added a response interceptor that clears the stored session id
when we encounter a `401 unauthorized` error. This doesn't go as far as
I would like, as ideally we'd then retry the request so it could pick up
a new session id, but when I tried that, I was getting weird behavior.
I'll leave it for later.

Finally, I also added some error handling to the `signIn` function to
handle cases where the endpoint returns `200 Ok` but the sign in request
actually fails.

closes #5
