### PR TITLE
Fix for Issue 15: RegulationMode and fallback.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { SchluterAPI } from './schluter-api';
+import { SchluterAPI, RegulationMode } from './schluter-api';
 import {
   AccessoryConfig,
   API,
@@ -17,6 +17,7 @@ class Thermostat {
   private readonly config: AccessoryConfig;
   private readonly thermostatService: Service;
   private readonly schluterAPI: SchluterAPI;
+  private regulationMode: RegulationMode;
 
   constructor(log: Logging, config: AccessoryConfig, api: API) {
     this.log = log;
@@ -28,6 +29,8 @@ class Thermostat {
       this.config.serial,
       this.log,
     );
+
+    this.regulationMode = this.config.regulationMode || RegulationMode.Schedule;
 
     this.thermostatService = new this.hap.Service.Thermostat(this.config.name);
 
@@ -81,8 +84,8 @@ class Thermostat {
   }
 
   handleTargetTemperatureSet(value) {
-    this.log.debug(`SET TargetTemperature ${value}`);
-    this.schluterAPI.setTargetTemperature(value);
+    this.log.debug(`SET TargetTemperature ${value} with Regulation Mode ${this.regulationMode}`);
+    this.schluterAPI.setTargetTemperature(value, this.regulationMode);
   }
 
   handleTemperatureDisplayUnitsGet() {

--- a/src/schluter-api.ts
+++ b/src/schluter-api.ts
@@ -11,6 +11,12 @@ enum TemperatureUnit {
   Fahrenheit = 1
 }
 
+export enum RegulationMode {
+  Schedule = 1,
+  Temporary = 2,
+  Permanent = 3
+}
+
 export class SchluterAPI {
   private static signInUrl = 'https://ditra-heat-e-wifi.schluter.com/api/authenticate/user';
   private static thermostatUrl = 'https://ditra-heat-e-wifi.schluter.com/api/thermostat';
@@ -90,11 +96,11 @@ export class SchluterAPI {
     await axios.put(SchluterAPI.accountUrl, data);
   }
 
-  async setTargetTemperature(targetTemperature: number) {
+  async setTargetTemperature(targetTemperature: number, RegulationMode: RegulationMode) {
     const params = { serialnumber: this.serialNumber };
     const data = {
       ComfortTemperature: Math.round(targetTemperature * 100),
-      RegulationMode: 2,
+      RegulationMode: RegulationMode,
     };
 
     await axios.post(SchluterAPI.thermostatUrl, data, { params: params });


### PR DESCRIPTION
Small changes to address [issue here](https://github.com/derekprior/homebridge-schluter-thermostat/issues/15).
The changes will allow the thermostat to maintain a permanent adjustment when the temperature is set, solving the issue with extended absences as you described.

**Configuration Example:**

To make this functional, you would add a line in your Homebridge configuration for your thermostat plugin like so:

`"regulationMode": 3`

This would set the mode to "Permanent" as per your choice.

**regulationMode:**

- 1 (Schedule): Follows the scheduled programming of the thermostat.
- 2 (Temporary): Temporarily overrides the current setting until the next scheduled change.
- 3 (Permanent): Overrides the current setting indefinitely until manually changed.